### PR TITLE
fix: remove failing apple build for now

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,6 @@ jobs:
     with:
       toolchain: stable
       targets: |
-        aarch64-apple-darwin
         x86_64-unknown-linux-gnu
     secrets:
       cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Nobody is using it anyway, people on OSX will just have to build themselves rather than running the binary