### PR TITLE
fix: restart log ingestor on config change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ edition = "2024"
 assets = [
     { source = "target/x86_64-unknown-linux-gnu/release/bec_log_ingestor", dest = "/usr/local/bin/bec_log_ingestor", mode = "755" },
     { source = "install/bec_log_ingestor.service", dest = "/lib/systemd/system/bec_log_ingestor.service", mode = "755" },
+    { source = "install/bec_log_ingestor-config.path", dest = "/lib/systemd/system/bec_log_ingestor-config.path", mode = "644" },
+    { source = "install/bec_log_ingestor-config.service", dest = "/lib/systemd/system/bec_log_ingestor-config.service", mode = "644" },
 ]
 pre_install_script = "install/setup_user"
 pre_install_script_prog = ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The `dtype` parameter represents how to parse the information obtained from Redi
 
 ### Deployment
 
-To use the systemd service as-is, a config should be created at `/etc/bec_log_ingestor.toml`, following the example in `install/example_config.toml`. For SLS deployments this is managed in puppet already.
+To use the systemd service as-is, a config should be created at `/etc/bec_log_ingestor.toml`, following the example in `install/example_config.toml`. The RPM also installs a systemd path unit that watches this file and `try-restart`s `bec_log_ingestor.service` when it changes. For SLS deployments this is managed in puppet already.
 
 Published RPM packages are signed by PGP, the corresponding public key is:
 

--- a/install/bec_log_ingestor-config.path
+++ b/install/bec_log_ingestor-config.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Watch bec_log_ingestor config for changes
+
+[Path]
+PathChanged=/etc/bec_log_ingestor.toml
+Unit=bec_log_ingestor-config.service
+
+[Install]
+WantedBy=multi-user.target

--- a/install/bec_log_ingestor-config.service
+++ b/install/bec_log_ingestor-config.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Restart bec_log_ingestor after config changes
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl try-restart bec_log_ingestor.service

--- a/install/restart_service
+++ b/install/restart_service
@@ -1,3 +1,4 @@
 # Try to restart the systemd service after installation
 systemctl daemon-reload
+systemctl enable --now bec_log_ingestor-config.path
 systemctl restart bec_log_ingestor.service


### PR DESCRIPTION
We independently deploy the config and the log ingestor through puppet. However, updating only the config did not lead to a restart of the service. Following @ivan-usov's  suggestion, a file watcher was added which triggers a try-restart on file changes. 