### PR TITLE
feat: improve log/metrics recovery semantics

### DIFF
--- a/src/loki_push.rs
+++ b/src/loki_push.rs
@@ -1,3 +1,4 @@
+use std::process::exit;
 use std::{collections::BTreeMap, time::Duration};
 
 use tokio::{
@@ -7,7 +8,7 @@ use tokio::{
 
 use crate::{
     config::{IngestorConfig, LokiConfig},
-    models::LogMsg,
+    models::{LogMsg, RedisLogBatch},
 };
 
 /// Convert a LogRecord to the document we want Loki to ingest
@@ -67,11 +68,19 @@ fn make_json_body(msgs: &[LogMsg], config: &'static IngestorConfig) -> serde_jso
 }
 
 pub async fn consumer_loop(
-    rx: &mut mpsc::UnboundedReceiver<LogMsg>,
+    rx: &mut mpsc::UnboundedReceiver<RedisLogBatch>,
+    ack_tx: mpsc::UnboundedSender<Vec<String>>,
     config: &'static IngestorConfig,
 ) {
-    let mut buffer: Vec<LogMsg> = Vec::with_capacity(config.loki.chunk_size.into());
-    let client = reqwest::Client::new();
+    let mut buffer: Vec<RedisLogBatch> = Vec::with_capacity(config.loki.chunk_size.into());
+    let mut records: Vec<LogMsg> = Vec::with_capacity(config.loki.chunk_size.into());
+    let mut ack_ids: Vec<String> = Vec::with_capacity(config.loki.chunk_size.into());
+    let mut body = String::new();
+    let mut retries: u8 = 0;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("Failed to build Loki HTTP client");
     let mut interval: Interval = (&config.loki.push_interval).into();
     println!(
         "INFO: Starting Loki consumer loop, pushing at {:?}.",
@@ -80,37 +89,74 @@ pub async fn consumer_loop(
 
     loop {
         interval.tick().await;
-        let open = rx
-            .recv_many(&mut buffer, config.loki.chunk_size.into())
-            .await;
+        let open = if buffer.is_empty() {
+            let open = rx
+                .recv_many(&mut buffer, config.loki.chunk_size.into())
+                .await;
+            if open == 0 {
+                break;
+            }
+            open
+        } else {
+            records.len()
+        };
         println!("DEBUG: Received {open} logs from redis.");
-        if open == 0 {
-            break;
+        if body.is_empty() {
+            records.clear();
+            ack_ids.clear();
+            for batch in &buffer {
+                ack_ids.extend(batch.entry_ids.iter().cloned());
+                records.extend(batch.records.iter().cloned());
+            }
+            body = make_json_body(&records, config).to_string();
         }
-        let body = make_json_body(&buffer, config).to_string();
         match client
             .post(&config.loki.url)
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .basic_auth(&config.loki.auth.username, Some(&config.loki.auth.password))
-            .body(body)
+            .body(body.clone())
             .send()
             .await
         {
             Ok(res) => {
-                println!("DEBUG: Sent {open} logs to loki. Response: {res:?}");
                 if !res.status().is_success() {
                     let text = res
                         .text()
                         .await
                         .unwrap_or("[Unable to decode response text!]".into());
-                    println!("ERROR: Received error response: {text} ");
+                    println!("ERROR: Received error response from Loki: {text}");
+                    retries = retries.saturating_add(1);
+                    if retries >= 3 {
+                        println!("ERROR: Maximum Loki retry attempts exceeded, exiting.");
+                        exit(69);
+                    }
+                    println!("WARNING: Retrying buffered logs in 5s.");
+                    sleep(Duration::from_secs(5)).await;
+                    continue;
+                }
+                retries = 0;
+                println!("DEBUG: Sent {open} logs to loki. Response: {res:?}");
+                if ack_tx.send(ack_ids.clone()).is_err() {
+                    println!("ERROR: Failed to send ack IDs back to Redis producer, exiting.");
+                    exit(69);
                 }
             }
             Err(res) => {
                 println!("ERROR: {res:?}");
+                retries = retries.saturating_add(1);
+                if retries >= 3 {
+                    println!("ERROR: Maximum Loki retry attempts exceeded, exiting.");
+                    exit(69);
+                }
+                println!("WARNING: Retrying buffered logs in 5s.");
+                sleep(Duration::from_secs(5)).await;
+                continue;
             }
         };
         buffer.clear();
+        records.clear();
+        ack_ids.clear();
+        body.clear();
         sleep(Duration::from_millis(10)).await;
     }
     println!("INFO: Producer dropped, consumer exiting");

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 use tokio::sync::mpsc;
 
 mod models;
-use crate::models::LogMsg;
+use crate::models::RedisLogBatch;
 
 mod config;
 use crate::config::{IngestorConfig, assemble_config};
@@ -69,9 +69,16 @@ async fn run_services(config: &'static IngestorConfig) {
 
     if config.enable_logging {
         println!("DEBUG: Starting log ingestor task...");
-        let (tx, mut rx) = mpsc::unbounded_channel::<LogMsg>();
-        let producer = tokio::spawn(producer_loop(tx, config, MAX_RETRIES, INITIAL_SLEEP));
-        consumer_loop(&mut rx, config).await;
+        let (tx, mut rx) = mpsc::unbounded_channel::<RedisLogBatch>();
+        let (ack_tx, ack_rx) = mpsc::unbounded_channel::<Vec<String>>();
+        let producer = tokio::spawn(producer_loop(
+            tx,
+            ack_rx,
+            config,
+            MAX_RETRIES,
+            INITIAL_SLEEP,
+        ));
+        consumer_loop(&mut rx, ack_tx, config).await;
         let _ = tokio::join!(producer);
     } else {
         _ = tokio::join!(metrics);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -267,13 +267,8 @@ async fn watchdog_loop(
             );
             for name in finished {
                 if let Some(metric_def) = metrics.get(&name) {
-                    match metric_def {
-                        crate::metrics_core::MetricDefinition::Static(_) => {
-                            let (_, handle) = spawner((&name, metric_def));
-                            futs.lock().await.insert(name, handle);
-                        }
-                        crate::metrics_core::MetricDefinition::Dynamic(_) => todo!(),
-                    }
+                    let (_, handle) = spawner((&name, metric_def));
+                    futs.lock().await.insert(name, handle);
                 }
             }
         }
@@ -286,9 +281,13 @@ async fn consumer_loop(rx: &mut mpsc::UnboundedReceiver<TimeSeries>, config: Met
     let chunk_size = 100;
     let mut buffer: Vec<TimeSeries> = Vec::with_capacity(chunk_size);
     let mut proto_encoded_buffer: Vec<u8> = Vec::new();
+    let mut compressed_buffer: Vec<u8> = Vec::new();
     let mut snap_encoder = Encoder::new();
     let mut retries: u8 = 0;
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("Failed to build metrics HTTP client");
     let mut interval: Interval = (&config.publish_interval).into();
 
     loop {
@@ -297,22 +296,32 @@ async fn consumer_loop(rx: &mut mpsc::UnboundedReceiver<TimeSeries>, config: Met
         }
         interval.tick().await;
         println!("DEBUG: publishing collected metrics to Mimir");
-        let open = rx.recv_many(&mut buffer, chunk_size).await;
-        if open == 0 {
-            break;
+        let open = if buffer.is_empty() {
+            let open = rx.recv_many(&mut buffer, chunk_size).await;
+            if open == 0 {
+                break;
+            }
+            open
+        } else {
+            buffer.len()
+        };
+        if proto_encoded_buffer.is_empty() {
+            let write_request = WriteRequest {
+                timeseries: buffer.clone(),
+            };
+            proto_encoded_buffer.reserve(write_request.encoded_len());
+            let Ok(()) = write_request.encode(&mut proto_encoded_buffer) else {
+                println!("ERROR: encountered an error in protobuf encoding. Exiting.");
+                break;
+            };
         }
-        let write_request = WriteRequest {
-            timeseries: buffer.clone(),
-        };
-        proto_encoded_buffer.reserve(write_request.encoded_len());
-        let Ok(()) = write_request.encode(&mut proto_encoded_buffer) else {
-            println!("ERROR: encountered an error in protobuf encoding. Exiting.");
-            break;
-        };
-        let Ok(compressed) = snap_encoder.compress_vec(&proto_encoded_buffer) else {
-            println!("ERROR: encountered an error in snappy compression. Exiting.");
-            break;
-        };
+        if compressed_buffer.is_empty() {
+            let Ok(compressed) = snap_encoder.compress_vec(&proto_encoded_buffer) else {
+                println!("ERROR: encountered an error in snappy compression. Exiting.");
+                break;
+            };
+            compressed_buffer = compressed;
+        }
 
         match client
             .post(&config.url)
@@ -320,34 +329,45 @@ async fn consumer_loop(rx: &mut mpsc::UnboundedReceiver<TimeSeries>, config: Met
             .header("Content-Encoding", "snappy")
             .header("User-Agent", format!("bec_log_ingestor v{APP_VERSION}"))
             .basic_auth(&config.auth.username, Some(&config.auth.password))
-            .body(compressed)
+            .body(compressed_buffer.clone())
             .send()
             .await
         {
             Ok(res) => {
-                retries = 0;
-                println!("DEBUG: Sent {open} metrics to Mimir.");
                 if !res.status().is_success() {
                     let text = res
                         .text()
                         .await
                         .unwrap_or("[Unable to decode response text!]".into());
-                    println!("ERROR: Received error response: {text} ");
+                    println!("ERROR: Received error response: {text}");
+                    retries = retries.saturating_add(1);
+                    if retries >= 3 {
+                        println!("ERROR: Maximum retry attempts exceeded, exiting.");
+                        exit(0x45); // Service unavailable
+                    }
+                    println!("DEBUG: Retrying in 5s.");
+                    sleep(Duration::from_secs(5)).await;
+                    continue;
                 }
+                retries = 0;
+                println!("DEBUG: Sent {open} metrics to Mimir.");
             }
             Err(res) => {
                 println!("ERROR: {res:?}");
-                if retries == 3 {
+                retries = retries.saturating_add(1);
+                if retries >= 3 {
                     println!("ERROR: Maximum retry attempts exceeded, exiting.");
                     exit(0x45); // Service unavailable
                 }
+                println!("WARNING: Send attempt {retries} failed; will retry buffered metrics.");
                 println!("DEBUG: Retrying in 5s.");
                 sleep(Duration::from_secs(5)).await;
-                retries += 1;
+                continue;
             }
         };
         buffer.clear();
         proto_encoded_buffer.clear();
+        compressed_buffer.clear();
     }
     println!("INFO: Producer dropped, consumer exiting");
 }

--- a/src/metrics_core.rs
+++ b/src/metrics_core.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use futures::StreamExt;
-use redis::{AsyncCommands, Msg, aio::MultiplexedConnection};
+use redis::{AsyncCommands, aio::MultiplexedConnection};
 use std::{
     collections::HashMap,
     pin::Pin,
@@ -19,7 +19,7 @@ use tokio::{
     spawn,
     sync::{Mutex, mpsc::UnboundedSender},
     task::JoinHandle,
-    time::{self, Interval},
+    time::{self, Duration, Interval, sleep},
 };
 
 pub mod prometheus {
@@ -401,7 +401,7 @@ fn dynamic_polling_metric<'a>(
         let val: Vec<u8> = redis
             .get(&config.key)
             .await
-            .map_err(|e| MetricError::Fatal(e.detail().unwrap_or("Unspecified").into()))?;
+            .map_err(|e| MetricError::Retryable(e.detail().unwrap_or("Unspecified").into()))?;
         if val.is_empty() {
             Err(MetricError::Retryable(format!(
                 "No value found at dynamically defined key: {:?}",
@@ -424,28 +424,65 @@ pub(crate) async fn dynamic_metric_future(
 ) {
     match &config.read_type {
         RedisReadType::PubSub => {
-            let client = redis::Client::open(redis_config.url.full_url())
-                .expect("Could not connect to redis!");
-            let mut pubsub = client
-                .get_async_pubsub()
-                .await
-                .expect("Could not get pubsub client!");
-            pubsub
-                .subscribe(&config.key)
-                .await
-                .expect("Could not subscribe to channel!");
-            pubsub
-                .on_message()
-                .map(|msg: Msg| {
-                    let payload: Vec<u8> = msg.get_payload().expect("Failed to extract payload!");
+            const PUBSUB_RETRY_DELAY: Duration = Duration::from_secs(5);
+
+            loop {
+                if STOP_METRICS.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                let client = match redis::Client::open(redis_config.url.full_url()) {
+                    Ok(client) => client,
+                    Err(error) => {
+                        println!(
+                            "WARNING: Could not connect pubsub metric {name} to redis: {error}"
+                        );
+                        sleep(PUBSUB_RETRY_DELAY).await;
+                        continue;
+                    }
+                };
+                let mut pubsub = match client.get_async_pubsub().await {
+                    Ok(pubsub) => pubsub,
+                    Err(error) => {
+                        println!(
+                            "WARNING: Could not create pubsub client for metric {name}: {error}"
+                        );
+                        sleep(PUBSUB_RETRY_DELAY).await;
+                        continue;
+                    }
+                };
+                if let Err(error) = pubsub.subscribe(&config.key).await {
+                    println!(
+                        "WARNING: Could not subscribe pubsub metric {name} to {}: {error}",
+                        &config.key
+                    );
+                    sleep(PUBSUB_RETRY_DELAY).await;
+                    continue;
+                }
+
+                let mut messages = pubsub.on_message();
+                while let Some(msg) = messages.next().await {
+                    if STOP_METRICS.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    let payload: Vec<u8> = match msg.get_payload() {
+                        Ok(payload) => payload,
+                        Err(error) => {
+                            println!(
+                                "WARNING: Failed to extract payload for pubsub metric {name}: {error}"
+                            );
+                            continue;
+                        }
+                    };
                     let (output, opt_extra_labels) =
                         match process_dynamic_message(&config, &payload) {
                             Err(MetricError::Fatal(error_msg)) => {
-                                panic!("FATAL: {error_msg}")
+                                println!("FATAL: {error_msg}");
+                                return;
                             }
                             Err(MetricError::Retryable(error_msg)) => {
                                 println!("WARNING: {error_msg}");
-                                return;
+                                continue;
                             }
                             Ok(res) => res,
                         };
@@ -455,12 +492,15 @@ pub(crate) async fn dynamic_metric_future(
                     }
                     for ts in output.to_timeseries(owned_labels, &name) {
                         if tx.send(ts).is_err() {
-                            panic!("TASK-FATAL: error transmitting metric to publisher channel");
+                            println!("TASK-FATAL: error transmitting metric to publisher channel");
+                            return;
                         }
                     }
-                })
-                .collect::<()>()
-                .await
+                }
+
+                println!("WARNING: Pubsub stream for metric {name} ended; reconnecting.");
+                sleep(PUBSUB_RETRY_DELAY).await;
+            }
         }
         RedisReadType::Poll(interval_config) => {
             let c = config.clone();

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,6 +2,12 @@ pub mod log_message;
 
 pub use log_message::{LogMessagePack, LogMsg, error_log_item};
 
+#[derive(Debug, Clone)]
+pub struct RedisLogBatch {
+    pub entry_ids: Vec<String>,
+    pub records: Vec<LogMsg>,
+}
+
 pub mod status_message;
 
 pub use status_message::{ServiceStatus, StatusMessagePack};

--- a/src/redis_logs.rs
+++ b/src/redis_logs.rs
@@ -1,5 +1,5 @@
 use crate::config::IngestorConfig;
-use crate::models::{LogMessagePack, LogMsg, error_log_item};
+use crate::models::{LogMessagePack, LogMsg, RedisLogBatch, error_log_item};
 use redis::Commands;
 use rmp_serde::Deserializer;
 use std::{thread, time::Duration};
@@ -65,7 +65,7 @@ fn stream_read_opts(config: &'static IngestorConfig) -> redis::streams::StreamRe
     redis::streams::StreamReadOptions::default()
         .count(config.redis.chunk_size.into())
         .block(config.redis.blocktime_millis)
-        .group("log-ingestor", "log-ingestor")
+        .group(&config.redis.consumer_group, &config.redis.consumer_id)
 }
 
 /// Fetch unread logs for redis.
@@ -74,13 +74,13 @@ fn read_logs(
     redis_conn: &mut redis::Connection,
     last_id: &String,
     config: &'static IngestorConfig,
-) -> Result<(Option<String>, Vec<redis::Value>), RedisError> {
+) -> Result<Vec<(String, redis::Value)>, RedisError> {
     let raw_reply: redis::streams::StreamReadReply = redis_conn
         .xread_options(&LOGGING_ENDPOINT, &[last_id], &stream_read_opts(config))
         .map_err(retryable_code)?;
 
     if raw_reply.keys.is_empty() {
-        return Ok((Some(last_id.to_owned()), vec![]));
+        return Ok(vec![]);
     }
 
     let log_key = raw_reply
@@ -88,19 +88,19 @@ fn read_logs(
         .first()
         .ok_or_else(|| RedisError::Retryable(KEY_MISMATCH.into()))?;
 
-    let last_id = log_key.ids.last().map(|i| i.id.clone());
-    let logs = log_key
+    log_key
         .ids
         .iter()
         .map(|e| {
-            e.map
-                .get("data")
-                .ok_or_else(|| RedisError::Retryable(NO_DATA.into()))
-                .cloned()
+            Ok((
+                e.id.clone(),
+                e.map
+                    .get("data")
+                    .ok_or_else(|| RedisError::Retryable(NO_DATA.into()))
+                    .cloned()?,
+            ))
         })
-        .collect::<Result<Vec<redis::Value>, RedisError>>()?;
-
-    Ok((last_id, logs))
+        .collect::<Result<Vec<(String, redis::Value)>, RedisError>>()
 }
 
 fn process_data(values: &Vec<redis::Value>) -> Result<Vec<LogMessagePack>, RedisError> {
@@ -130,6 +130,20 @@ fn extract_records(messages: &Vec<LogMessagePack>) -> Vec<LogMsg> {
         .iter()
         .map(|e| e.bec_codec.data.log_msg.clone())
         .collect()
+}
+
+fn ack_logs(
+    redis_conn: &mut redis::Connection,
+    config: &'static IngestorConfig,
+    entry_ids: &[String],
+) -> Result<(), RedisError> {
+    if entry_ids.is_empty() {
+        return Ok(());
+    }
+    let _: usize = redis_conn
+        .xack(&LOGGING_ENDPOINT, &config.redis.consumer_group, entry_ids)
+        .map_err(retryable_code)?;
+    Ok(())
 }
 
 fn setup_consumer_group(
@@ -180,30 +194,57 @@ fn check_connection(
 }
 
 pub async fn producer_loop(
-    tx: mpsc::UnboundedSender<LogMsg>,
+    tx: mpsc::UnboundedSender<RedisLogBatch>,
+    mut ack_rx: mpsc::UnboundedReceiver<Vec<String>>,
     config: &'static IngestorConfig,
     max_retries: u8,
     initial_sleep: u64,
 ) -> Result<(), RedisError> {
     let mut redis_conn = create_redis_conn_with_retry(config, max_retries, initial_sleep)?;
-    let stream_read_id: String = ">".into();
+    let mut stream_read_id: String = "0".into();
     println!("DEBUG: Starting Loki task producer loop");
     'main: loop {
         // Sleep between blocking calls prevents starvation of other tasks in thread limited environments
         sleep(Duration::from_millis(10)).await;
         match read_logs(&mut redis_conn, &stream_read_id, config) {
-            Ok(response) => {
-                if let (Some(_), packed) = response {
-                    if packed.is_empty() {
-                        continue;
+            Ok(entries) => {
+                if entries.is_empty() {
+                    if stream_read_id != ">" {
+                        stream_read_id = ">".into();
                     }
-                    for record in extract_records(&process_data(&packed).unwrap_or_else(|_| {
-                        println!("WARNING: failed to process record: {:?}", &packed);
-                        vec![error_log_item(packed.clone())]
-                    })) {
-                        if tx.send(record).is_err() {
-                            println!("INFO: Receiver dropped, stopping...");
-                            break 'main Ok(());
+                    continue;
+                }
+
+                let packed: Vec<redis::Value> =
+                    entries.iter().map(|(_, value)| value.clone()).collect();
+                let entry_ids: Vec<String> = entries.iter().map(|(id, _)| id.clone()).collect();
+                let records = extract_records(&process_data(&packed).unwrap_or_else(|_| {
+                    println!("WARNING: failed to process record: {:?}", &packed);
+                    vec![error_log_item(packed.clone())]
+                }));
+                let batch = RedisLogBatch { entry_ids, records };
+
+                stream_read_id = batch.entry_ids.last().cloned().unwrap_or(stream_read_id);
+
+                if tx.send(batch).is_err() {
+                    println!("INFO: Receiver dropped, stopping...");
+                    break 'main Ok(());
+                }
+
+                let acked_ids = match ack_rx.recv().await {
+                    Some(acked_ids) => acked_ids,
+                    None => {
+                        println!("INFO: Ack receiver dropped, stopping...");
+                        break 'main Ok(());
+                    }
+                };
+                loop {
+                    match ack_logs(&mut redis_conn, config, &acked_ids) {
+                        Ok(()) => break,
+                        Err(e) => {
+                            println!("ERROR: {:?}", e);
+                            redis_conn =
+                                create_redis_conn_with_retry(config, max_retries, initial_sleep)?;
                         }
                     }
                 }

--- a/src/tests/loki_integration_test.rs
+++ b/src/tests/loki_integration_test.rs
@@ -15,7 +15,7 @@ use tokio::{
 use crate::{
     config::IngestorConfig,
     loki_push::consumer_loop,
-    models::LogMsg,
+    models::RedisLogBatch,
     redis_logs::{RedisError, create_redis_conn_with_retry, producer_loop},
 };
 
@@ -97,9 +97,10 @@ async fn test_loki_no_endpoint() {
         let config: &'static mut IngestorConfig =
             Box::leak(Box::new(config(redis_url, redis_port, "".into())));
 
-        let (tx, _) = mpsc::unbounded_channel::<LogMsg>();
+        let (tx, _) = mpsc::unbounded_channel::<RedisLogBatch>();
+        let (_ack_tx, ack_rx) = mpsc::unbounded_channel::<Vec<String>>();
 
-        let result = producer_loop(tx, config, 1, 10).await;
+        let result = producer_loop(tx, ack_rx, config, 1, 10).await;
         assert_eq!(
             result,
             Err(RedisError::Fatal((
@@ -150,12 +151,13 @@ async fn channels_and_tasks(
     config: &'static mut IngestorConfig,
 ) -> (JoinHandle<Result<(), RedisError>>, JoinHandle<()>) {
     println!("Spawning tasks");
-    let (tx, rx) = mpsc::unbounded_channel::<LogMsg>();
+    let (tx, rx) = mpsc::unbounded_channel::<RedisLogBatch>();
+    let (ack_tx, ack_rx) = mpsc::unbounded_channel::<Vec<String>>();
     let rxbox: &'static mut UnboundedReceiver<_> = Box::leak(Box::new(rx));
-    let producer = tokio::spawn(producer_loop(tx, config, 3, 100));
+    let producer = tokio::spawn(producer_loop(tx, ack_rx, config, 3, 100));
     println!("Spawned producer in timeout");
     sleep(Duration::from_millis(10)).await;
-    let consumer = tokio::spawn(consumer_loop(rxbox, config));
+    let consumer = tokio::spawn(consumer_loop(rxbox, ack_tx, config));
     println!("Spawned consumer");
     (producer, consumer)
 }


### PR DESCRIPTION
- Dynamic metric polling now retries
- Reworked dynamic PubSub metrics to reconnect cleanly on Redis/pubsub failures instead of panicking on client, subscribe, payload, or stream errors.
- Added bounded retry behavior for Loki and Mimir publishing, with request timeouts and preserved in-memory batches across retry attempts.
- Added ACK-based Redis log delivery so log entries are only acknowledged after a successful Loki push.
- Added pending-log recovery on restart by draining this consumer’s pending entries before switching back to new messages.